### PR TITLE
(or,and)_parser is fixed and workes same as bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@
 #    By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/13 12:36:09 by kuzyilma          #+#    #+#              #
-#    Updated: 2025/03/06 11:18:37 by kuzyilma         ###   ########.fr        #
+#    Updated: 2025/06/02 15:09:12 by kuzyilma         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 MAIN_SRC = main.c main_utils.c
 SPLIT_SRC = t_split_utils.c ft_split_quotes.c
-AOPSR_SRC = parser_and_or.c and_or_utils.c
+AOPSR_SRC = parser_and_or.c and_or_utils.c parser_and_or2.c
 SOA_SRC = sep_opt_arg/sep_opt_arg.c
 
 SRC = $(addprefix main/, $(MAIN_SRC)) $(addprefix t_split_utils/, $(SPLIT_SRC)) $(addprefix and_or_parser/, $(AOPSR_SRC)) $(SOA_SRC)

--- a/and_or_parser/and_or_utils.c
+++ b/and_or_parser/and_or_utils.c
@@ -6,7 +6,7 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/22 18:55:15 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/03/22 14:58:01 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/01 17:41:08 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,6 +42,8 @@ int	countchr_str(char*str, char c)
 
 	j = 0;
 	count = 0;
+	if (str == NULL || *str == '\0')
+		return (0);
 	while (str[j] != '\0')
 	{
 		if (str[j] == c)
@@ -61,6 +63,8 @@ int	countchr_quote(char *str, char c)
 	j = 0;
 	count = 0;
 	inquote = 0;
+	if (str == NULL || *str == '\0')
+		return (0);
 	while (str[j] != '\0')
 	{
 		inquote ^= (str[j] == '\"' && inquote != 2);

--- a/and_or_parser/parser_and_or.c
+++ b/and_or_parser/parser_and_or.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_and_or.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
+/*   By: emgenc <emgenc@student.42istanbul.com.t    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/06/02 15:11:00 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:42:20 by emgenc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,9 +59,9 @@ char	*get_cut_indexs(t_split split)
 		par += countchr_not_quote(split.start[i], '(');
 		if (par == 0)
 		{
-			if (strncmp("||", split.start[i], 3) == 0)
+			if (ft_strncmp("||", split.start[i], 3) == 0)
 				ret[check++] = '1';
-			else if (strncmp("&&", split.start[i], 3) == 0)
+			else if (ft_strncmp("&&", split.start[i], 3) == 0)
 				ret[check++] = '0';
 		}
 		par -= countchr_not_quote(split.start[i], ')');
@@ -83,8 +83,8 @@ void	parse_and_or(t_shell *shell, t_split split, char *c_i)
 	while (++i <= split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if ((par == 0) && ((i == split.size) || (strncmp("&&", split.start[i], \
-		4) == 0) || (strncmp("||", split.start[i], 4) == 0)))
+		if (par == 0 && (i == split.size || ft_strncmp("&&", split.start[i], \
+			4) == 0 || ft_strncmp("||", split.start[i], 4) == 0))
 		{
 			if (split.start[i] != NULL)
 				free(split.start[i]);

--- a/and_or_parser/parser_and_or.c
+++ b/and_or_parser/parser_and_or.c
@@ -6,7 +6,7 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/06/02 13:23:48 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/02 13:51:27 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -99,7 +99,6 @@ char *get_cut_indexs(t_split split)
 				ret[check++] = '0';
 		}
 		par -= countchr_not_quote(split.start[i], ')');
-		printf("%d-%s ",i ,ret);
 		i++;
 	}
 	return (ret);
@@ -141,7 +140,6 @@ void	parser_and_or(t_shell *shell, t_split split)
 {
 	char	*cut_indexs;
 
-	print_result(&split);
 	if (split.size <= 0 || split.start == NULL)
 		return ;
 	if (check_single_par(split) != 0)
@@ -157,5 +155,5 @@ void	parser_and_or(t_shell *shell, t_split split)
 	free(cut_indexs);
 	}
 	else
-		{/*executer*/}
+		{printf("%s\n", split.start[0]);}
 }

--- a/and_or_parser/parser_and_or.c
+++ b/and_or_parser/parser_and_or.c
@@ -6,7 +6,7 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/06/01 17:50:54 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/02 13:23:48 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,7 @@ int	count_str_split(t_split split, const char *str, int flag)
 	while (i < split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if ((flag == 1 || par == 0) && (strncmp(str, split.start[i], 4) == 0))
+		if ((flag == 0 || par == 0) && (strncmp(str, split.start[i], 4) == 0))
 			count++;
 		par -= countchr_not_quote(split.start[i], ')');
 		i++;
@@ -80,9 +80,11 @@ char *get_cut_indexs(t_split split)
 	int i;
 	int par;
 	char *ret;
+	int check;
 
 	i = 0;
 	par = 0;
+	check = 0;
 	ret = ft_calloc(count_str_split(split, "||", 1) + count_str_split(split, "&&", 1) + 1, sizeof(char));
 	if (ret == NULL)
 		return (NULL);
@@ -91,12 +93,13 @@ char *get_cut_indexs(t_split split)
 		par += countchr_not_quote(split.start[i], '(');
 		if (par == 0) 
 		{
-			if(strncmp("||", split.start[i], 4) == 0)
-				ret[i] = 1;
-			else if (strncmp("&&", split.start[i], 4) == 0)
-				ret[i] = 0;
+			if(strncmp("||", split.start[i], 3) == 0)
+				ret[check++] = '1';
+			else if (strncmp("&&", split.start[i], 3) == 0)
+				ret[check++] = '0';
 		}
 		par -= countchr_not_quote(split.start[i], ')');
+		printf("%d-%s ",i ,ret);
 		i++;
 	}
 	return (ret);
@@ -116,14 +119,14 @@ void parse_and_or(t_shell *shell, t_split split, char *cut_indexs)
 	while (i <= split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if (i = split.size || strncmp("&&", split.start[i], 4) == 0 || strncmp("||", split.start[i], 4) == 0)
+		if ((par == 0) && ((i == split.size) || (strncmp("&&", split.start[i], 4) == 0) || (strncmp("||", split.start[i], 4) == 0)))
 		{
 			if (split.start[i] != NULL)
 				free(split.start[i]);
 			split.start[i] = NULL;
 			if (check == -1 || \
-				(cut_indexs[check] == 0 && shell->past_exit_status == 0) || \
-				(cut_indexs[check] == 1 && shell->past_exit_status != 0))
+				(cut_indexs[check] == '0' && shell->past_exit_status == 0) || \
+				(cut_indexs[check] == '1' && shell->past_exit_status != 0))
 				parser_and_or(shell, create_split(&(split.start[start]), i - start));
 			start = i + 1;
 			check++;

--- a/and_or_parser/parser_and_or.c
+++ b/and_or_parser/parser_and_or.c
@@ -6,25 +6,11 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/06/02 14:22:35 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/02 15:11:00 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../main/minishell.h"
-
-void print_result(t_split *test)
-{
-    int i;
-    printf("\n\tsize: %d", test->size);
-    printf("\n\tstart:%3p", test->start);
-    i = 0;
-    while(i <= test->size)
-    {
-        printf("\n\t\t%-2d:%s", i, test->start[i]);
-        i++;
-    }
-    printf(" -> after last value\n");
-}
 
 // Cuts out the outermost (). New string == empty? Remove it from 'split'
 static void	cut_out_par(t_split *split)
@@ -54,88 +40,68 @@ static void	cut_out_par(t_split *split)
 		split->size--;
 }
 
-// counts exact str in split's str array . if flag = 1 does not count str in paranthesis
-int	count_str_split(t_split split, const char *str, int flag)
+char	*get_cut_indexs(t_split split)
 {
-	int i;
-	int count;
-	int par;
+	int		i;
+	int		par;
+	char	*ret;
+	int		check;
 
-	i = 0;
-	count = 0;
-	par = 0;
-	while (i < split.size)
-	{
-		par += countchr_not_quote(split.start[i], '(');
-		if ((flag == 0 || par == 0) && (strncmp(str, split.start[i], 4) == 0))
-			count++;
-		par -= countchr_not_quote(split.start[i], ')');
-		i++;
-	}
-	return (count);
-}
-
-char *get_cut_indexs(t_split split)
-{
-	int i;
-	int par;
-	char *ret;
-	int check;
-
-	i = 0;
+	i = -1;
 	par = 0;
 	check = 0;
-	ret = ft_calloc(count_str_split(split, "||", 1) + count_str_split(split, "&&", 1) + 1, sizeof(char));
+	ret = ft_calloc(count_str_split(split, "||", 1) + \
+	count_str_split(split, "&&", 1) + 1, sizeof(char));
 	if (ret == NULL)
 		return (NULL);
-	while (i < split.size)
+	while (++i < split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if (par == 0) 
+		if (par == 0)
 		{
-			if(strncmp("||", split.start[i], 3) == 0)
+			if (strncmp("||", split.start[i], 3) == 0)
 				ret[check++] = '1';
 			else if (strncmp("&&", split.start[i], 3) == 0)
 				ret[check++] = '0';
 		}
 		par -= countchr_not_quote(split.start[i], ')');
-		i++;
 	}
 	return (ret);
 }
 
-void parse_and_or(t_shell *shell, t_split split, char *cut_indexs)
+void	parse_and_or(t_shell *shell, t_split split, char *c_i)
 {
-	int i;
-	int par;
-	int start;
-	int check;
+	int	i;
+	int	par;
+	int	st;
+	int	check;
 
 	i = -1;
 	par = 0;
-	start = 0;
+	st = 0;
 	check = -2;
 	while (++i <= split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if ((par == 0) && ((i == split.size) || (strncmp("&&", split.start[i], 4) == 0) || (strncmp("||", split.start[i], 4) == 0)))
+		if ((par == 0) && ((i == split.size) || (strncmp("&&", split.start[i], \
+		4) == 0) || (strncmp("||", split.start[i], 4) == 0)))
 		{
 			if (split.start[i] != NULL)
 				free(split.start[i]);
 			split.start[i] = NULL;
-			if (++check == -1 || \
-				(cut_indexs[check] == '0' && shell->past_exit_status == 0) || \
-				(cut_indexs[check] == '1' && shell->past_exit_status != 0))
-				parser_and_or(shell, create_split(&(split.start[start]), i - start));
-			start = i + 1;
+			if (++check == -1 || (c_i[check] == '0' && shell->past_exit_status \
+			== 0) || (c_i[check] == '1' && shell->past_exit_status != 0))
+				parser_and_or(shell, create_split(&(split.start[st]), i - st));
+			st = i + 1;
 		}
 		par -= countchr_not_quote(split.start[i], ')');
 	}
 }
-int paranthesis_parity_check(t_split split)
+
+int	paranthesis_parity_check(t_split split)
 {
-	int i;
-	int par;
+	int	i;
+	int	par;
 
 	i = 0;
 	par = 0;
@@ -149,6 +115,7 @@ int paranthesis_parity_check(t_split split)
 		return (1);
 	return (0);
 }
+
 // Parser for && and || with () priority
 void	parser_and_or(t_shell *shell, t_split split)
 {
@@ -169,10 +136,10 @@ void	parser_and_or(t_shell *shell, t_split split)
 	}
 	if (count_str_split(split, "||", 1) + count_str_split(split, "&&", 1) > 0)
 	{
-	cut_indexs = get_cut_indexs(split);
-	parse_and_or(shell, split, cut_indexs);
-	free(cut_indexs);
+		cut_indexs = get_cut_indexs(split);
+		parse_and_or(shell, split, cut_indexs);
+		free(cut_indexs);
 	}
 	else
-		{printf("%s\n", split.start[0]);}
+		{/*executer*/}
 }

--- a/and_or_parser/parser_and_or2.c
+++ b/and_or_parser/parser_and_or2.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_and_or2.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
+/*   Updated: 2025/06/02 15:09:28 by kuzyilma         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../main/minishell.h"
+
+// counts exact str in split's str array . if flag = 1 doesn't paranthesis
+int	count_str_split(t_split split, const char *str, int flag)
+{
+	int	i;
+	int	count;
+	int	par;
+
+	i = 0;
+	count = 0;
+	par = 0;
+	while (i < split.size)
+	{
+		par += countchr_not_quote(split.start[i], '(');
+		if ((flag == 0 || par == 0) && (strncmp(str, split.start[i], 4) == 0))
+			count++;
+		par -= countchr_not_quote(split.start[i], ')');
+		i++;
+	}
+	return (count);
+}

--- a/and_or_parser/parser_and_or2.c
+++ b/and_or_parser/parser_and_or2.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_and_or2.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
+/*   By: emgenc <emgenc@student.42istanbul.com.t    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/20 19:15:24 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/06/02 15:09:28 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:33:48 by emgenc           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,8 @@ int	count_str_split(t_split split, const char *str, int flag)
 	while (i < split.size)
 	{
 		par += countchr_not_quote(split.start[i], '(');
-		if ((flag == 0 || par == 0) && (strncmp(str, split.start[i], 4) == 0))
+		if ((flag == 0 || par == 0)
+			&& (ft_strncmp(str, split.start[i], 4) == 0))
 			count++;
 		par -= countchr_not_quote(split.start[i], ')');
 		i++;

--- a/and_or_parser/test_and_or.sh
+++ b/and_or_parser/test_and_or.sh
@@ -110,7 +110,8 @@ test_case "1&&(2||3)&&4&&(5||6)&&7" "Alternating nested structure"
 test_case "1&&(2||3||(4&&5||(6&&7)))" "Complex nested fallback logic"
 test_case "((((1||2)&&3)||4)&&5)||(6&&7)" "Stress test for parser"
 test_case "1||(2&&(3||(4&&(5||(6&&(7))))))" "Deep hybrid nest"
-
+test_case "1&&(2||(3&&4&&5)&&7||8)||9&&10" "random stuff"
+test_case "1 && (2 ||( 3&&  4&&  5) &&7  ||8)   ||9  && 10" "random stuff"
 
 
 # ========== SUMMARY ==========

--- a/and_or_parser/test_and_or.sh
+++ b/and_or_parser/test_and_or.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# === Configuration ===
+PARSER_EXEC="./minishell"  # ← Change to your actual parser binary
+PROMPT_REGEX='^minishell *>?'
+
+
+pass=0
+fail=0
+test_index=1
+
+# Run a test case
+test_case() {
+    local raw_input="$1"
+    local desc="$2"
+
+    echo "Test $test_index: $desc"
+    echo "Expression: $raw_input"
+
+    # Convert raw expression to echo version for Bash
+    local bash_expr
+    bash_expr=$(echo "$raw_input" | sed -E 's/([0-9]+)/echo \1/g')
+
+    # Bash output
+    bash_output=$(bash -c "$bash_expr" 2>&1)
+
+    # Parser output
+    parser_output=$(echo "$raw_input" | "$PARSER_EXEC" 2>&1)
+
+    # Remove any lines starting with "minishell >" or "minishell>"
+    parser_output_cleaned=$(echo "$parser_output" | grep -vE "$PROMPT_REGEX")
+
+    # Compare
+    if [ "$bash_output" = "$parser_output_cleaned" ]; then
+        echo "✅ PASS"
+        ((pass++))
+    else
+        echo "❌ FAIL"
+        echo "--- Bash output ---"
+        echo "$bash_output"
+        echo "--- Minishell output ---"
+        echo "$parser_output_cleaned"
+        ((fail++))
+    fi
+
+    echo
+    ((test_index++))
+}
+
+# ========== BASIC TEST CASES ==========
+
+test_case "1&&2" "Simple AND"
+test_case "1||2" "Simple OR"
+
+
+
+
+# ========== SEQUENCED OPERATORS ==========
+
+test_case "1&&2||3" "AND followed by OR"
+test_case "1||2&&3" "OR followed by AND"
+test_case "1&&2&&3" "Chained ANDs"
+test_case "1||2||3" "Chained ORs"
+
+
+
+
+# ========== MIXED & COMPLEX EXPRESSIONS ==========
+
+test_case "1&&2||3&&4" "Mix of AND and OR"
+test_case "1||2&&3||4" "OR AND OR"
+test_case "1&&2||3||4" "AND then OR chain"
+test_case "1||2||3&&4&&5" "OR chain with final ANDs"
+test_case "1&&2&&3||4||5" "Three ANDs followed by two ORs"
+
+
+
+
+# ========== EDGE CASES ==========
+
+test_case "1" "Single command"
+test_case "1||2&&3&&4||5&&6" "Complex short-circuit behavior"
+test_case "1&&2||3&&4||5" "Balanced mixed logic"
+test_case "1&&2&&3&&4" "Long AND chain"
+test_case "1||2||3||4" "Long OR chain"
+
+
+
+
+# ========== WHITESPACE CASES ==========
+
+test_case "  1  &&  2 " "AND with extra spaces"
+test_case "1   ||    2" "OR with extra spaces"
+test_case "  1  && 2 ||  3 " "AND-OR with mixed spacing"
+
+
+
+
+# ========== SUMMARY ==========
+
+echo "========================="
+echo "Tests passed: $pass"
+echo "Tests failed: $fail"

--- a/and_or_parser/test_and_or.sh
+++ b/and_or_parser/test_and_or.sh
@@ -52,18 +52,12 @@ test_case() {
 test_case "1&&2" "Simple AND"
 test_case "1||2" "Simple OR"
 
-
-
-
 # ========== SEQUENCED OPERATORS ==========
 
 test_case "1&&2||3" "AND followed by OR"
 test_case "1||2&&3" "OR followed by AND"
 test_case "1&&2&&3" "Chained ANDs"
 test_case "1||2||3" "Chained ORs"
-
-
-
 
 # ========== MIXED & COMPLEX EXPRESSIONS ==========
 
@@ -73,9 +67,6 @@ test_case "1&&2||3||4" "AND then OR chain"
 test_case "1||2||3&&4&&5" "OR chain with final ANDs"
 test_case "1&&2&&3||4||5" "Three ANDs followed by two ORs"
 
-
-
-
 # ========== EDGE CASES ==========
 
 test_case "1" "Single command"
@@ -84,15 +75,41 @@ test_case "1&&2||3&&4||5" "Balanced mixed logic"
 test_case "1&&2&&3&&4" "Long AND chain"
 test_case "1||2||3||4" "Long OR chain"
 
-
-
-
 # ========== WHITESPACE CASES ==========
 
 test_case "  1  &&  2 " "AND with extra spaces"
 test_case "1   ||    2" "OR with extra spaces"
 test_case "  1  && 2 ||  3 " "AND-OR with mixed spacing"
 
+# ========== KUZEY'S EXTRAS ==========
+test_case "1&&(2||3)" "AND with OR in parentheses"
+test_case "(1&&2)||3" "Parenthesized AND followed by OR"
+test_case "1||(2&&3)" "OR with AND in parentheses"
+test_case "(1||2)&&(3||4)" "Multiple ORs in parentheses combined with AND"
+test_case "1&&((2||3)&&4)" "Nested parentheses"
+test_case "((1&&2)||3)&&4" "Parentheses on both sides"
+test_case "(((1))))" "Unbalanced parentheses (expect your parser to error)"
+test_case "(1&&2)||(3&&(4||5))" "Balanced deep logic"
+test_case "(1||2)||(3&&4)||5" "Long OR chain in parentheses"
+test_case "((1&&2)&&3)||(4&&(5||6))" "Complex nested logic"
+test_case "1&&2&&3&&4&&5&&6&&7" "Long AND chain"
+test_case "1||2||3||4||5||6||7" "Long OR chain"
+test_case "1&&2||3&&4||5&&6||7" "Alternating chain"
+test_case "((((1&&2)||3)&&4)||5)&&6" "Nested and layered logic"
+test_case "1&&(2&&(3&&(4&&(5&&6))))" "Deep AND nesting"
+test_case "(1||2)&&(3||4)&&(5||6)" "Sequential parenthesized ORs"
+test_case "(1&&(2||3))||4" "Mixed levels"
+test_case "((1&&2)||(3||4))&&5" "Dual nesting"
+test_case "(1&&(2&&(3||(4&&5))))" "Hybrid nested logic"
+test_case "(1)||(2||(3||(4||(5))))" "Deep OR nesting"
+test_case "(1&&2)||(3&&4)||(5&&6)" "Balanced complex expression"
+test_case "1&&2&&(3||4||5)&&6&&7" "Complex AND with OR middle"
+test_case "((1&&2&&3)||(4&&5&&6))&&(7||8||9)" "Balanced performance test"
+test_case "(1)||((2)&&((3)||(4)))" "Multi-layer group"
+test_case "1&&(2||3)&&4&&(5||6)&&7" "Alternating nested structure"
+test_case "1&&(2||3||(4&&5||(6&&7)))" "Complex nested fallback logic"
+test_case "((((1||2)&&3)||4)&&5)||(6&&7)" "Stress test for parser"
+test_case "1||(2&&(3||(4&&(5||(6&&(7))))))" "Deep hybrid nest"
 
 
 

--- a/main/main.c
+++ b/main/main.c
@@ -6,7 +6,7 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/08 10:55:46 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/04/15 14:06:19 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/02 14:04:30 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,6 @@ static void	start_shell(t_shell *shell)
 		{
 			sep_opt_arg(shell);
 			shell->split_input = create_split_str(shell->current_input);
-			printf("%s\n", shell->current_input);
 			parser_and_or(shell, shell->split_input);
 			free_split(&(shell->split_input));
 		}

--- a/main/minishell.h
+++ b/main/minishell.h
@@ -6,7 +6,7 @@
 /*   By: kuzyilma <kuzyilma@student.42istanbul.c    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/08 10:53:30 by kuzyilma          #+#    #+#             */
-/*   Updated: 2025/04/15 14:03:44 by kuzyilma         ###   ########.fr       */
+/*   Updated: 2025/06/02 15:08:43 by kuzyilma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,5 +41,6 @@ int		countchr_not_quote(char*str, char c);
 int		check_single_par(t_split split);
 int		check_symbol(t_split split, char *find, int flag);
 void	sep_opt_arg(t_shell *shell);
+int		count_str_split(t_split split, const char *str, int flag);
 
 #endif


### PR DESCRIPTION
- changed logic to be same as bash
-added a simple error catch when paranthesis parity isn't right
-made everything norm appropriate.